### PR TITLE
Fix example for matching 404 page in React

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,17 @@ import { router } from '../stores/router.js'
 
 export const Layout = () => {
   const page = useStore(router)
+
+  if (!page) {
+    return <Error404 />
+  }
+
   if (page.route === 'home') {
     return <HomePage />
   } else if (page.route === 'category') {
     return <CategoryPage categoryId={page.params.categoryId} />
   } else if (page.route === 'post') {
     return <PostPage postId={page.params.postId} />
-  } else {
-    return <Error404 />
   }
 }
 ```


### PR DESCRIPTION
There is a TypeScript problem somewhere because in case of 404 `page` is `undefined`, but I wasn't able to find out where it happens.
