### PR TITLE
Save url search params in links

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export function createRouter(routes) {
 
   let prev
   let parse = path => {
-    path = path.replace(/\/$/, '') || '/'
+    path = path.split('?')[0].replace(/\/$/, '') || '/'
     if (prev === path) return false
     prev = path
 
@@ -58,7 +58,7 @@ export function createRouter(routes) {
       if (url.origin === location.origin) {
         event.preventDefault()
         let changed = location.hash !== url.hash
-        router.open(url.pathname)
+        router.open(url.pathname + url.search)
         if (changed) {
           location.hash = url.hash
           if (url.hash === '' || url.hash === '#') {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -386,6 +386,17 @@ test('supports link with hash in URL and different path', () => {
   equal(events, ['/posts'])
 })
 
+test('supports link with search in URL and different path', () => {
+  changePath('/')
+  let events = listen()
+
+  let link = createTag(document.body, 'a', { href: '/posts?q=1#hash' })
+  link.click()
+
+  equal(location.search, '?q=1')
+  equal(events, ['/posts'])
+})
+
 test('generates artificial hashchange event for empty hash', () => {
   changePath('/#hash')
   let events = listen()


### PR DESCRIPTION
Fixed https://github.com/nanostores/router/issues/7
Url search added to url but ignored on parsing.