### PR TITLE
fix(typo): Fix typo in example section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import { createRouter } from '@nanostores/router'
 export const router = createRouter({
   home: '/',
   category: '/posts/:categoryId',
-  post: '/posts/:categoryId/:id'
+  post: '/posts/:categoryId/:postId'
 } as const)
 ```
 


### PR DESCRIPTION
This PR a typo in `README.md`