### PR TITLE
Optional params for getPagePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ export function getPagePath(router, name, params) {
   }
   let path = route[3]
     .replace(/\/:\w+\?/g, i => {
-      let param = params[i.slice(2).slice(0, -1)]
+      let param = params ? params[i.slice(2).slice(0, -1)] : null
       if (param) {
         return '/' + encodeURIComponent(param)
       } else {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -384,6 +384,7 @@ test('generates URLs', () => {
     getPagePath(router, 'optional', { id: '10', tab: 'a#b' }),
     '/profile/10/a%23b'
   )
+  equal(getPagePath(router, 'optional'), '/profile')
 })
 
 test('opens URLs manually by route name, pushing new stare', () => {


### PR DESCRIPTION
Types allow you to leave params optional, but an error appears:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'id')
```