### PR TITLE
Fix regular expression for optional params

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A tiny URL router for [Nano Stores](https://github.com/nanostores/nanostores)
 state manager.
 
-* **Small.** 685 bytes (minified and brotlied). Zero dependencies.
+* **Small.** 696 bytes (minified and brotlied). Zero dependencies.
 * Good **TypeScript** support.
 * Framework agnostic. Can be used with **React**, **Preact**, **Vue**,
   **Svelte**, **Angular**, **Solid.js**, and vanilla JS.

--- a/index.js
+++ b/index.js
@@ -9,14 +9,16 @@ export function createRouter(routes, opts = {}) {
       let names = value.match(/(?<=\/:)\w+/g) || []
       let pattern = value
         .replace(/[\s!#$()+,.:<=?[\\\]^{|}]/g, '\\$&')
-        .replace(/\/\\:\w+\\\?/g, '/?([^/]*)')
+        .replace(/\/\\:\w+\\\?/g, '(?:/((?<=/)[^/]+))?')
         .replace(/\/\\:\w+/g, '/([^/]+)')
       return [
         name,
         RegExp('^' + pattern + '$', 'i'),
         (...matches) =>
           matches.reduce((params, match, index) => {
-            params[names[index]] = decodeURIComponent(match)
+            // match === undefined when nothing captured in regexp group
+            // and we swap it with empty string for backward compatibility
+            params[names[index]] = match ? decodeURIComponent(match) : ''
             return params
           }, {}),
         value

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nanostores/router",
   "version": "0.14.1",
-  "description": "A tiny (685 bytes) router for Nano Stores state manager",
+  "description": "A tiny (696 bytes) router for Nano Stores state manager",
   "keywords": [
     "nano",
     "router",
@@ -103,7 +103,7 @@
       "import": {
         "./index.js": "{ createRouter }"
       },
-      "limit": "685 B"
+      "limit": "696 B"
     }
   ],
   "clean-publish": {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -185,6 +185,18 @@ test('parameters can be optional', () => {
     route: 'optional',
     search: {}
   })
+
+  changePath('/profile//')
+  deepStrictEqual(router.get(), undefined)
+
+  changePath('/profile///')
+  deepStrictEqual(router.get(), undefined)
+
+  changePath('/profile-missed-route')
+  deepStrictEqual(router.get(), undefined)
+
+  changePath('/profile/10/contacts/20')
+  deepStrictEqual(router.get(), undefined)
 })
 
 test('detects URL changes', () => {


### PR DESCRIPTION
The router converts patterns with optional parameters to regular expressions that are not strict enough. 

Example: `/profile/:id?/:tab?` matches `/profile-random-bug`, `/profile//` and `/profile///` paths.

This PR fixes it. 

11 bytes added.