### PR TITLE
Named capturing groups proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A tiny URL router for [Nano Stores](https://github.com/nanostores/nanostores)
 state manager.
 
-* **Small.** 696 bytes (minified and brotlied). Zero dependencies.
+* **Small.** 684 bytes (minified and brotlied). Zero dependencies.
 * Good **TypeScript** support.
 * Framework agnostic. Can be used with **React**, **Preact**, **Vue**,
   **Svelte**, **Angular**, **Solid.js**, and vanilla JS.

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ type PathToParams<PathArray, Params = {}> = PathArray extends [
 
 type ParseUrl<Path extends string> = PathToParams<Split<Path, '/'>>
 
-export type RouterConfig = Record<string, Pattern<any> | string>
+export type RouterConfig = Record<string, Pattern<any> | RegExp | string>
 
 export type ConfigFromRouter<SomeRouter> = SomeRouter extends Router<
   infer Config

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nanostores/router",
   "version": "0.14.1",
-  "description": "A tiny (696 bytes) router for Nano Stores state manager",
+  "description": "A tiny (684 bytes) router for Nano Stores state manager",
   "keywords": [
     "nano",
     "router",
@@ -103,7 +103,7 @@
       "import": {
         "./index.js": "{ createRouter }"
       },
-      "limit": "696 B"
+      "limit": "684 B"
     }
   ],
   "clean-publish": {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -52,6 +52,7 @@ function createTag(
 let router = createRouter({
   draft: [/\/posts\/(draft|new)\/(\d+)/, (type, id) => ({ id, type })],
   home: '/',
+  named: /\/named\/(?<type>draft|new)\/(?<id>\d+)/,
   optional: '/profile/:id?/:tab?',
   post: '/posts/:categoryId/:id',
   posts: '/posts/',
@@ -398,12 +399,22 @@ test('ignores the same URL in manual URL', () => {
   deepStrictEqual(events, [])
 })
 
-test('allows RegExp routes', () => {
+test('allows RegExp routes with callback', () => {
   changePath('/posts/draft/10/')
   deepStrictEqual(router.get(), {
     params: { id: '10', type: 'draft' },
     path: '/posts/draft/10',
     route: 'draft',
+    search: {}
+  })
+})
+
+test('allows RegExp routes without callback', () => {
+  changePath('/named/draft/10/')
+  deepStrictEqual(router.get(), {
+    params: { id: '10', type: 'draft' },
+    path: '/named/draft/10',
+    route: 'named',
     search: {}
   })
 })


### PR DESCRIPTION
While [fixing RegExp for optional params](https://github.com/nanostores/router/pull/32) I got an idea and here is an example of how [named capturing groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) can be used for params detection. Not sure if it should be merged or not. In general I only want to highlight a possible direction of thinking for future improvements.

This PR
* allow to define RegExp routes without callback
* removes the neediness of callbacks for string patterns (identically closures was defined for each route previously)
* provides a little bit cleaner way for params extraction from path (standard language feature used instead of fetch by index from extracted by regex parameters names array)
* reduce size by 12 bytes

---

How named capturing works:

```js
let path = "/profile/10/contacts"
let pattern = /\/profile\/(?<id>\d+)\/(?<tab>\w+)/

path.match(pattern)

[
  '/profile/10/contacts',
  '10',
  'contacts',
  index: 0,
  input: '/profile/10/contacts',
  groups: [Object: null prototype] { id: '10', tab: 'contacts' } // ← our desired params
]
```

Also, with named capturing groups it's possible to create links for regex routes. It's not bulletproof and production ready cause it’s impossible to handle all regex related features here, but can be used in simple cases when regex pattern contains only parameter value type checking like in example below.

```js
function regexpRouteLink(regexp, params) {
  let link = regexp.source
    .replace(/\\\//g, '/')
    .replace(/^\^/, '')
    .replace(/\$$/, '')
	
  Object.entries(params).forEach(p => {
    link = link.replace(new RegExp(`(\\(\\?<${p[0]}>[^/]*\\))`), p[1])
  })

  return link;
}

let regexp = /^\/profile\/(?<id>\d+)\/(?<tab>\w+)$/i

regexpRouteLink(regexp, { id: 10, tab: 'contacts' }) // => /profile/10/contacts
```