### PR TITLE
Docs: Extend search params section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ createRouter({
 Router value contains parsed url search params:
 
 ```js
-createRouter({ home: '/posts/:category?sort=name' })
+createRouter({ home: '/posts/:category' })
 
 location.href = '/posts/general?sort=name'
 router.get() //=> {

--- a/README.md
+++ b/README.md
@@ -114,30 +114,34 @@ createRouter({
 
 ### Search Query Routing
 
-Router value contains parsed `?a=1&b=2` search values:
+Router value contains parsed url search params:
 
 ```js
+createRouter({ home: '/posts/:category?sort=name' })
+
 location.href = '/posts/general?sort=name'
 router.get() //=> {
-//                   path: '/posts/category',
+//                   path: '/posts/general',
 //                   route: 'list',
 //                   params: { category: 'general' },
 //                   search: { sort: 'name' }
 //                 }
 ```
 
-To use search query like `?a=1&b=2` in routes you need to set `search` option:
+To disable the automatic parsing of search params in routes you need to set `search` option.
+Router will now treat search query like `?a=1&b=2` as a string. Parameters order will be critical.
 
 ```js
-createRouter({
-  home: '/p/?page=home'
-}, {
-  search: true
-})
-```
+createRouter({ home: '/posts?page=general' }, { search: true })
 
-Router will work with `?search` part as a string. Parameters order will
-be critical.
+location.href = '/posts/?page=general'
+router.get() //=> {
+//                   path: '/posts?page=general',
+//                   route: 'list',
+//                   params: { },
+//                   search: { }
+//                 }
+```
 
 
 ### Clicks Tracking


### PR DESCRIPTION
Following the advice from https://github.com/nanostores/router/issues/34#issuecomment-2118444983 I was trying to clarify the search params section of the readme.

Changes include
- Using the term "url search params" which what they are called in https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams
- Make the default case a bit more obvious by adding the corresponding `createRouter`
- Clarify that the `search:true` disables something, not enables something, BUT…

… I still don't quite understand what the usecase for `search:true` is and how it would be used in an app.
I tried to use it in my app but failed to get something working that made sense.
This is my I mark this as a draft for now until this part is improved.
I also don't understand what "Parameters order will be critical." means. "Critical" in what way?