### PR TITLE
Docs: Improve search query routing part on search params

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ createRouter({
 Router value contains parsed url search params:
 
 ```js
-createRouter({ home: '/posts/:category?sort=name' })
+createRouter({ home: '/posts/:category' })
 
 location.href = '/posts/general?sort=name'
 router.get() //=> {

--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ createRouter({
 
 ### Search Query Routing
 
-Router value contains parsed `?a=1&b=2` search values:
+Router value contains parsed url search params:
 
 ```js
+createRouter({ home: '/posts/:category?sort=name' })
+
 location.href = '/posts/general?sort=name'
 router.get() //=> {
-//                   path: '/posts/category',
+//                   path: '/posts/general',
 //                   route: 'list',
 //                   params: { category: 'general' },
 //                   search: { sort: 'name' }


### PR DESCRIPTION
This is a part of https://github.com/nanostores/router/pull/35 but the part that I am confident on. I would have helped me to understand the setup better, with those proposed changes present.

However, the part that I did not change here "To use search query like…" which I tried to clarify in  https://github.com/nanostores/router/pull/35 is still  confusing for me and even this this change here it would have likely lead me to add `search:true`.

My suggestion is to merge this part but also improve https://github.com/nanostores/router/pull/35.