### PR TITLE
Docs: Improve click tracking example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ You can disable this behavior by `links: false` options and create custom
 export const $router = createRouter({ … }, { links: false })
 
 function onClick (e) {
-  let link = event.target.closest('a')
-  if (isPjax(link, e)) {
-    $router.open(new Url(link.href).pathname)
-  }
+  e.preventDefault()
+  let path = new Url(event.target.href).pathname
+  let params = $router.get()?.search
+  openPage($router, '…', { }, { ...params })
 }
 
 export const Link = (props) => {

--- a/README.md
+++ b/README.md
@@ -158,9 +158,7 @@ export const $router = createRouter({ … }, { links: false })
 
 function onClick (e) {
   e.preventDefault()
-  let path = new Url(event.target.href).pathname
-  let params = $router.get()?.search
-  openPage($router, '…', { }, { ...params })
+  $router.open(new Url(e.target.href).pathname)
 }
 
 export const Link = (props) => {


### PR DESCRIPTION
A few things that improve this example IMO

- remove `isPjax` reference which [looks like](https://www.google.com/search?q=isPjax) something from laravel(?) and is [not part of the codebase](https://github.com/search?q=repo%3Ananostores%2Frouter%20isPjax&type=code)
- add `preventDefault` which is needed here IMO
- use `openPage` which is a nice helper to use here IMO
- suggest preserving the page search params with `params`