### PR TITLE
SPA without HTML5 routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+* Optional no HTML5 routing
+
 ## 1.0.0
 * Added Nano Stores 1.0 support.
 * Removed Node.js 18 support.

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,7 @@ export type Page<
 export interface RouterOptions {
   links?: boolean
   search?: boolean
+  html5?: boolean
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ export function createRouter(routes, opts = {}) {
   let prev
   let parse = href => {
     let url = new URL(href.replace(/#$/, ''), 'http://a')
+    if (opts.html5 === false) {
+      url = new URL(url.hash.substring(1), 'http://a');
+    }
     let cache = url.pathname + url.search + url.hash
     if (prev === cache) return false
     prev = cache

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import { atom, onMount } from 'nanostores'
 
 export function createRouter(routes, opts = {}) {
   let router = atom()
+  router.opts = opts;
   router.routes = Object.keys(routes).map(name => {
     let pattern = routes[name]
 
@@ -150,7 +151,7 @@ export function getPagePath(router, name, params, search) {
     let postfix = '' + new URLSearchParams(search)
     if (postfix) return path + '?' + postfix
   }
-  return path
+  return router.opts.html5 === false ? '#' + path : path
 }
 
 export function openPage(router, name, params, search) {


### PR DESCRIPTION
This commit should enable SPA without HTML5 routing.

ex:

```html
    <p><a href="#/">home</a></p>
    <p><a href="#/logout">logout</a></p>
    <p><a href="#/image/123456?editor=true">edit image</a></p>
```

```javascript
import { createRouter } from "@nanostores/router";

export const $router = createRouter({
  home: "/",
  image: "/image/:id",
  logout: "/logout",
}, { html5: false });
```
