### PR TITLE
Allow preventing navigation with onSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A tiny URL router for [Nano Stores](https://github.com/nanostores/nanostores)
 state manager.
 
-- **Small.** 712 bytes (minified and brotlied). Zero dependencies.
+- **Small.** 725 bytes (minified and brotlied). Zero dependencies.
 - Good **TypeScript** support.
 - Framework agnostic. Can be used with **React**, **Preact**, **Vue**,
   **Svelte**, **Angular**, **Solid.js**, and vanilla JS.
@@ -219,6 +219,29 @@ All functions accept search params as last argument:
 getPagePath($router, 'list', { category: 'guides' }, { sort: 'name' })
 //=> '/posts/guides?sort=name'
 ```
+
+### Preventing Navigation
+
+Navigation is derived from the store value: the URL changes only after the
+store changed. So you can use Nano Stores `onSet` event to prevent navigation,
+for example, to keep the user on a form with unsaved changes.
+
+```ts
+import { onSet } from 'nanostores'
+
+onSet($router, ({ newValue, abort }) => {
+  if (hasUnsavedChanges && !confirm('Discard changes?')) {
+    abort()
+  }
+})
+```
+
+`abort()` stops `$router.open()`, `openPage()`, `redirectPage()`, and tracked
+`<a>` clicks: neither the store nor the URL will change.
+
+Browser Back/Forward buttons change the URL before `onSet` runs,
+so `abort()` will keep the store on the old value but will **not** roll back the
+address bar. Add your own `history.pushState` in the listener if you need that.
 
 ### Server-Side Rendering
 

--- a/index.js
+++ b/index.js
@@ -37,11 +37,11 @@ export function createRouter(routes, opts = {}) {
           params: callback
             ? callback(...match.slice(1))
             : Object.keys({ ...match.groups }).reduce((params, key) => {
-                params[key] = match.groups[key]
-                  ? decodeURIComponent(match.groups[key])
-                  : ''
-                return params
-              }, {}),
+              params[key] = match.groups[key]
+                ? decodeURIComponent(match.groups[key])
+                : ''
+              return params
+            }, {}),
           path,
           route,
           search: Object.fromEntries(url.searchParams)
@@ -68,8 +68,7 @@ export function createRouter(routes, opts = {}) {
     ) {
       event.preventDefault()
       let hashChanged = location.hash !== link.hash
-      router.open(link.href)
-      if (hashChanged) {
+      if (router.open(link.href) && hashChanged) {
         location.hash = link.hash
         if (link.hash === '' || link.hash === '#') {
           window.dispatchEvent(new HashChangeEvent('hashchange'))
@@ -78,20 +77,14 @@ export function createRouter(routes, opts = {}) {
     }
   }
 
-  let set = router.set
-  if (process.env.NODE_ENV !== 'production') {
-    delete router.set
-  }
-
   let change = () => {
     let page = parse(location.href)
-    if (page !== false) set(page)
+    if (page !== false) router.set(page)
   }
 
   if (typeof window !== 'undefined' && typeof location !== 'undefined') {
     onMount(router, () => {
-      let page = parse(location.href)
-      if (page !== false) set(page)
+      change()
       if (opts.links !== false) document.body.addEventListener('click', click)
       window.addEventListener('popstate', change)
       window.addEventListener('hashchange', change)
@@ -103,20 +96,20 @@ export function createRouter(routes, opts = {}) {
       }
     })
   } else {
-    set(parse('/'))
+    router.set(parse('/'))
   }
 
   router.open = (path, redirect) => {
     let page = parse(path)
     if (page !== false) {
-      if (typeof history !== 'undefined') {
-        if (redirect) {
-          history.replaceState(null, null, path)
-        } else {
-          history.pushState(null, null, path)
+      router.set(page)
+      if (router.value === page) {
+        if (typeof history !== 'undefined') {
+          history[redirect ? 'replaceState' : 'pushState'](null, null, path)
         }
+        return page
       }
-      set(page)
+      prev = undefined
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nanostores/router",
   "version": "1.0.0",
-  "description": "A tiny (712 bytes) router for Nano Stores state manager",
+  "description": "A tiny (725 bytes) router for Nano Stores state manager",
   "keywords": [
     "nano",
     "preact",
@@ -60,7 +60,7 @@
       "import": {
         "./index.js": "{ createRouter }"
       },
-      "limit": "712 B"
+      "limit": "725 B"
     }
   ],
   "engines": {
@@ -68,5 +68,6 @@
   },
   "clean-publish": {
     "cleanDocs": true
-  }
+  },
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,5 @@
   },
   "clean-publish": {
     "cleanDocs": true
-  },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
+  }
 }

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom'
-import { cleanStores } from 'nanostores'
+import { cleanStores, onSet } from 'nanostores'
 import { deepStrictEqual, equal, throws } from 'node:assert'
 import { afterEach, test } from 'node:test'
 
@@ -740,4 +740,80 @@ test('supports dot in URL', () => {
 
   changePath('/page.html')
   deepStrictEqual(otherRouter.get(), undefined)
+})
+
+test('allows to prevent open() by onSet', () => {
+  changePath('/')
+  let events = listen()
+  let unbind = onSet(router, ({ abort }) => {
+    abort()
+  })
+
+  router.open('/posts/guides/10')
+
+  equal(router.get()?.path, '/')
+  equal(location.href, 'http://localhost/')
+  deepStrictEqual(events, [])
+  unbind()
+})
+
+test('allows to prevent openPage and redirectPage by onSet', () => {
+  changePath('/')
+  let unbind = onSet(router, ({ abort }) => {
+    abort()
+  })
+
+  openPage(router, 'post', { categoryId: 'guides', id: '10' })
+  equal(router.get()?.path, '/')
+  equal(location.href, 'http://localhost/')
+
+  redirectPage(router, 'post', { categoryId: 'guides', id: '10' })
+  equal(router.get()?.path, '/')
+  equal(location.href, 'http://localhost/')
+  unbind()
+})
+
+test('allows to prevent link click by onSet', () => {
+  changePath('/')
+  let events = listen()
+  let unbind = onSet(router, ({ abort }) => {
+    abort()
+  })
+
+  createTag(document.body, 'a', { href: '/posts?a=1' }).click()
+
+  equal(router.get()?.path, '/')
+  equal(location.href, 'http://localhost/')
+  deepStrictEqual(events, [])
+  unbind()
+})
+
+test('does not change hash when onSet aborts link click', () => {
+  changePath('/posts')
+  let unbind = onSet(router, ({ abort }) => {
+    abort()
+  })
+
+  createTag(document.body, 'a', { href: '/posts#hash' }).click()
+
+  equal(location.hash, '')
+  equal(router.get()?.hash, '')
+  unbind()
+})
+
+test('allows to navigate again after onSet abort', () => {
+  changePath('/')
+  let events = listen()
+
+  let unbind = onSet(router, ({ abort }) => {
+    abort()
+  })
+  router.open('/posts/guides/10')
+  equal(router.get()?.path, '/')
+  unbind()
+
+  router.open('/posts/guides/10')
+  equal(router.get()?.path, '/posts/guides/10')
+  equal(location.href, 'http://localhost/posts/guides/10')
+  deepStrictEqual(events, ['/posts/guides/10'])
 })


### PR DESCRIPTION
I added support for onSet, enabling navigation to be intercepted and optionally blocked. This makes the router store the single source of truth for routing state.
As a result, the private setter is no longer needed, since the router state is no longer tightly coupled to the current URL. (For now, I have kept it as a read-only atom.)
The change adds only 13 bytes to the bundle size and passes all existing tests without requiring any updates. The new functionality is fully covered by additional tests.

Minimal onSet example:

```ts
import { onSet } from 'nanostores'

onSet($router, ({ newValue, abort }) => {
  if (hasUnsavedChanges && !confirm('Discard changes?')) {
    abort()
  }
})
```

Example of implementing a React Router–style useBlocker in Preact/React:

```ts
import { onSet } from "nanostores";
import { useCallback, useEffect, useRef, useState } from "preact/hooks";

import { $router } from "./store/router";

function useBlocker(router, shouldBlock) {
  const allowed = useRef(false);
  const nextPath = useRef(null);
  const [blocked, setBlocked] = useState(false);

  useEffect(() => {
    return onSet(router, ({ newValue, abort }) => {
      if (!shouldBlock(newValue) || allowed.current) return;

      abort();
      nextPath.current = newValue?.path;
      setBlocked(true);
    });
  }, [router, shouldBlock]);

  const reset = useCallback(() => {
    nextPath.current = null;
    setBlocked(false);
  }, []);

  const proceed = useCallback(() => {
    const path = nextPath.current;
    reset();

    if (path) {
      allowed.current = true;
      router.open(path);
    }
  }, [router, reset]);

  return { blocked, proceed, reset };
}

function ImportantPage() {
  const blockPredicate = useCallback(() => true, []);
  const blocker = useBlocker($router, blockPredicate);

  return (
    <div>
      <h1>Important page</h1>

      <dialog open={blocker.blocked}>
        <button onClick={blocker.proceed}>GO!</button>
        <button onClick={blocker.reset}>Cancel</button>
      </dialog>
    </div>
  );
}
```